### PR TITLE
Sleep 3 sec to wait to start HTTP server

### DIFF
--- a/src/test/java/com/yasuenag/checkpointer/test/CheckpointerAgentTest.java
+++ b/src/test/java/com/yasuenag/checkpointer/test/CheckpointerAgentTest.java
@@ -70,6 +70,9 @@ public class CheckpointerAgentTest{
     CheckpointerAgent.premain(null);
     Assertions.assertEquals("com.yasuenag.checkpointer.crac", System.getProperty("org.crac.Core.Compat"));
 
+    // Sleep 3 sec to wait to start HTTP server...
+    Thread.sleep(3000);
+
     ResourceTestImpl resource = new ResourceTestImpl();
     Core.getGlobalContext().register(resource);
 


### PR DESCRIPTION
GHA reported following error:

```
[INFO] Running com.yasuenag.checkpointer.test.CheckpointerAgentTest
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.530 s <<< FAILURE! -- in com.yasuenag.checkpointer.test.CheckpointerAgentTest
Error:  com.yasuenag.checkpointer.test.CheckpointerAgentTest.testCheckpointerAgent -- Time elapsed: 0.527 s <<< ERROR!
java.io.IOException: HTTP/1.1 header parser received no bytes
	at java.net.http/jdk.internal.net.http.HttpClientImpl.send(HttpClientImpl.java:570)
	at java.net.http/jdk.internal.net.http.HttpClientFacade.send(HttpClientFacade.java:119)
	at com.yasuenag.checkpointer.test.CheckpointerAgentTest.testCheckpointerAgent(CheckpointerAgentTest.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
```